### PR TITLE
Add astropy as a requirement in the setup.py file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     name="hdstats",
     packages=find_packages(),
     setup_requires=["pytest-runner", "Cython>=0.23"],
-    install_requires=["numpy", "Cython>=0.23"],
+    install_requires=["numpy", "Cython>=0.23", "astropy"],
     tests_require=["pytest"],
     version="0.1",
     description="High-dimensional statistics.",


### PR DESCRIPTION
Pretty sure this is required and wasn't installed when I used the setup.py to install the package.