### PR TITLE
Fixes for (u)int16 geomedian code paths

### DIFF
--- a/hdstats/pcm.pyx
+++ b/hdstats/pcm.pyx
@@ -385,7 +385,7 @@ def __gm_int16(const int16_t [:, :, :, :] X, floating [:, :, :] mX,
                         break
 
                 for j in range(p):
-                    mX[row, col, j] = y1[j]
+                    mX[row, col, j] = (y1[j] - offset)/scale
 
         free(Dinv)
         free(y1)
@@ -574,7 +574,7 @@ def __gm_uint16(const uint16_t [:, :, :, :] X, floating [:, :, :] mX,
                         break
 
                 for j in range(p):
-                    mX[row, col, j] = y1[j]
+                    mX[row, col, j] = (y1[j] - offset)/scale
 
         free(Dinv)
         free(y1)

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     extras_require={
         'test': tests_require,
     },
-    version="0.1.7",
+    version="0.1.7.post3",
     description="High-dimensional statistics.",
     url="http://github.com/daleroberts/hdstats",
     author="Dale Roberts",

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     extras_require={
         'test': tests_require,
     },
-    version="0.1.7.post3",
+    version="0.1.7.post5",
     description="High-dimensional statistics.",
     url="http://github.com/daleroberts/hdstats",
     author="Dale Roberts",

--- a/tests/test_pcm.py
+++ b/tests/test_pcm.py
@@ -21,7 +21,7 @@ class TestPixelCompositeMosaic:
         fixeddata = (self.data * 10000).astype(np.int16)
 #        fixeddata[1,1,0,:] = -999
         fgm = hdstats.nangeomedian_pcm(fixeddata)
-        gm = hdstats.nangeomedian_pcm(self.data)
+        gm = hdstats.nangeomedian_pcm(self.data)*10000
         npt.assert_approx_equal(np.nanmean(fgm), np.nanmean(gm),
                                 significant=4)
 


### PR DESCRIPTION
- Allow user to control scale/offset to apply to (u)int16 input data
- Make sure output is scaled back to the same space as input.